### PR TITLE
Support Vercel Edge Runtime

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -8,7 +8,8 @@ import { encodeUTF16toUTF8 } from "./utfx.js";
 export const nextTick =
   typeof process !== "undefined" &&
   process &&
-  typeof process.nextTick === "function"
+  typeof process.nextTick === "function" &&
+  process.env.NEXT_RUNTIME !== "edge"
     ? typeof setImmediate === "function"
       ? setImmediate
       : // eslint-disable-next-line @typescript-eslint/unbound-method


### PR DESCRIPTION
The current check for the `nextTick()` function is insufficient on Vercel's Edge Runtime, rendering this library unusable, because although `typeof setImmediate === "function"`, it errors saying this Node API is unsupported. Therefore, an extra check is needed to ensure that it instead uses `setTimeout` when `process.env.NEXT_RUNTIME === "edge"`.