### PR TITLE
Add source information in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,10 @@
     "email": "mister-hope@outlook.com",
     "url": "https://mister-hope.com"
   },
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/Mister-Hope/bcrypt-ts.git"
+  },
   "type": "module",
   "exports": {
     ".": {


### PR DESCRIPTION
There is no link to this repository from https://www.npmjs.com/package/bcrypt-ts